### PR TITLE
fix Mopidy-GMusic deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN set -ex \
         Mopidy-Moped \
         Mopidy-GMusic \
         Mopidy-YouTube \
+        pyasn1==0.1.8 \
  && apt-get purge --auto-remove -y \
         curl \
         gcc \


### PR DESCRIPTION
before got error `INFO Disabled extension gmusic: (pyasn1 0.1.7 (/usr/lib/python2.7/dist-packages), Requirement.parse('pyasn1>=0.1.8'), set(['pyasn1-modules']))`