### PR TITLE
Install yt 'bad' decoders.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ RUN set -ex \
         curl \
         gcc \
         gstreamer0.10-alsa \
+        gstreamer0.10-plugins-bad \
+        gstreamer1.0-plugins-bad \
         python-crypto \
  && curl -L https://apt.mopidy.com/mopidy.gpg -o /tmp/mopidy.gpg \
  && curl -L https://apt.mopidy.com/mopidy.list -o /etc/apt/sources.list.d/mopidy.list \


### PR DESCRIPTION
This fixes issues where some youtube tracks would not play with following warning:

```
WARNING  2017-02-20 20:21:13,385 [1:MainThread] mopidy.audio.gst
  GStreamer warning: gst-stream-error-quark: No decoder available for type 'audio/mpeg, mpegversion=(int)4, framed=(boolean)true, stream-format=(string)raw, level=(string)2, base-profile=(string)lc, profile=(string)lc, codec_data=(buffer)1210, rate=(int)44100, channels=(int)2'. (6)
```

Similar issue:
https://github.com/rectalogic/mopidy-pandora/issues/56