### PR TITLE
Use Pulseaudio native using docker volume.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,7 @@
 FROM debian:jessie
 
-# Default configuration
-COPY mopidy.conf /var/lib/mopidy/.config/mopidy/mopidy.conf
-
-# Start helper script
-COPY entrypoint.sh /entrypoint.sh
+# Set the username
+ENV UNAME user
 
 RUN set -ex \
     # Official Mopidy install for Debian/Ubuntu along with some extensions
@@ -32,27 +29,29 @@ RUN set -ex \
         Mopidy-GMusic \
         Mopidy-YouTube \
         pyasn1==0.1.8 \
-    # Install dumb-init
-    # https://github.com/Yelp/dumb-init
- && DUMP_INIT_URI=$(curl -L https://github.com/Yelp/dumb-init/releases/latest | grep -Po '(?<=href=")[^"]+_amd64(?=")') \
- && curl -Lo /usr/local/bin/dumb-init "https://github.com/$DUMP_INIT_URI" \
- && chmod +x /usr/local/bin/dumb-init \
     # Clean-up
  && apt-get purge --auto-remove -y \
         curl \
         gcc \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* ~/.cache \
-    # Limited access rights.
- && chown mopidy:audio -R /var/lib/mopidy/.config \
- && chown mopidy:audio /entrypoint.sh
+ # Create the user
+ && useradd -m -d /home/${UNAME} ${UNAME} \
+ # Create the config dir
+ && mkdir -p /home/${UNAME}/.config/mopidy/ \
+ && chown -R ${UNAME} /home/${UNAME}/
 
-# Run as mopidy user
-USER mopidy
+# Copy the pulse-client configuratrion
+COPY pulse-client.conf /etc/pulse/client.conf
+
+# Run as user
+USER ${UNAME}
+
+# Default configuration
+COPY mopidy.conf /home/${UNAME}/.config/mopidy/mopidy.conf
 
 VOLUME ["/var/lib/mopidy/local", "/var/lib/mopidy/media"]
 
 EXPOSE 6600 6680
 
-ENTRYPOINT ["/usr/local/bin/dumb-init", "/entrypoint.sh"]
 CMD ["/usr/bin/mopidy"]

--- a/README.md
+++ b/README.md
@@ -20,31 +20,20 @@ You may install additional [backend extensions](https://docs.mopidy.com/en/lates
 ### Usage
 
 #### PulseAudio over network
+    
+    Mount the current user's pulse directory to the pulseuadio user (id - 105)
+    Based on: https://github.com/TheBiggerGuy/docker-pulseaudio-example
 
-First to make [audio from from within a Docker container](http://stackoverflow.com/q/28985714/167897), you should enable [PulseAudio over network](https://wiki.freedesktop.org/www/Software/PulseAudio/Documentation/User/Network/); so if you have X11 you may for example do:
+    $ docker run -d \
+      -v /run/user/$(id -u)/pulse:/run/user/105/pulse \
+      -p 6600:6600 -p 6680:6680 \
+      wernight/mopidy 
 
- 1. Install [PulseAudio Preferences](http://freedesktop.org/software/pulseaudio/paprefs/). Debian/Ubuntu users can do this:
-
-        $ sudo apt-get install paprefs
-
- 2. Launch `paprefs` (PulseAudio Preferences) > "*Network Server*" tab > Check "*Enable network access to local sound devices*" (you may check "*Don't require authentication*" to avoid mounting cookie file described below).
-
- 3. Restart PulseAudio
-
-        $ sudo service pulseaudio restart
-
-    or
-
-        $ pulseaudio -k
-        $ pulseaudio --start
-
-    On some distributions, it may be necessary to completely restart your computer. You can confirm that the settings have successfully been applied running `pax11publish | grep -Eo 'tcp:[^ ]*'`. You should see something like `tcp:myhostname:4713`.
 
 #### General usage
 
     $ docker run -d \
-          -e "PULSE_SERVER=tcp:$(hostname -i):4713" \
-          -e "PULSE_COOKIE_DATA=$(pax11publish -d | grep --color=never -Po '(?<=^Cookie: ).*')" \
+          -v /run/user/$(id -u)/pulse:/run/user/105/pulse \
           -v "$PWD/media:/var/lib/mopidy/media:ro" \
           -v "$PWD/local:/var/lib/mopidy/local" \
           -p 6600:6600 -p 6680:6680 \
@@ -67,10 +56,6 @@ Ports:
   * 6600 - MPD server (if you use for example ncmpcpp client)
   * 6680 - HTTP server (if you use your browser as client)
 
-Environment variables:
-
-  * `PULSE_SERVER` - PulseAudio server socket.
-  * `PULSE_COOKIE_DATA` - Hexadecimal encoded PulseAudio cookie commonly at `~/.config/pulse/cookie`.
 
 Volumes:
 
@@ -83,8 +68,7 @@ Volumes:
  2. Index local files:
 
         $ docker run --rm \
-              -e "PULSE_SERVER=tcp:$(hostname -i):4713" \
-              -e "PULSE_COOKIE_DATA=$(pax11publish -d | grep --color=never -Po '(?<=^Cookie: ).*')" \
+              -v /run/user/$(id -u)/pulse:/run/user/105/pulse \
               -v "$PWD/media:/var/lib/mopidy/media:ro" \
               -v "$PWD/local:/var/lib/mopidy/local" \
               -p 6680:6680 \
@@ -93,8 +77,7 @@ Volumes:
  3. Start the server:
 
         $ docker run -d \
-              -e "PULSE_SERVER=tcp:$(hostname -i):4713" \
-              -e "PULSE_COOKIE_DATA=$(pax11publish -d | grep --color=never -Po '(?<=^Cookie: ).*')" \
+              -v /run/user/$(id -u)/pulse:/run/user/105/pulse \
               -v "$PWD/media:/var/lib/mopidy/media:ro" \
               -v "$PWD/local:/var/lib/mopidy/local" \
               -p 6680:6680 \
@@ -105,8 +88,7 @@ Volumes:
 #### Example using [ncmpcpp](https://docs.mopidy.com/en/latest/clients/mpd/#ncmpcpp) MPD console client
 
     $ docker run --name mopidy -d \
-          -e "PULSE_SERVER=tcp:$(hostname -i):4713" \
-          -e "PULSE_COOKIE_DATA=$(pax11publish -d | grep --color=never -Po '(?<=^Cookie: ).*')" \
+          -v /run/user/$(id -u)/pulse:/run/user/105/pulse \
           wernight/mopidy
     $ docker run --rm -it --link mopidy:mopidy wernight/ncmpcpp ncmpcpp --host mopidy
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-if [[ "$PULSE_COOKIE_DATA" != "" ]]
-then
-    echo -ne $(echo $PULSE_COOKIE_DATA | sed -e 's/../\\x&/g') >$HOME/pulse.cookie
-    export PULSE_COOKIE=$HOME/pulse.cookie
-fi
-
-exec "$@"

--- a/pulse-client.conf
+++ b/pulse-client.conf
@@ -1,0 +1,9 @@
+# Connect to the host's server using the mounted UNIX socket
+default-server = unix:/run/user/105/pulse/native
+
+# Prevent a server running in the container
+autospawn = no
+daemon-binary = /bin/true
+
+# Prevent the use of shared memory
+enable-shm = false


### PR DESCRIPTION
Dockerfile modified to use the native pulseaudo instead of pulseaudio over network.
Dumb-init removed, entrypoint.sh removed.
Pulse-client.conf added.