### PR TITLE
fixing cookie data and swapping youtube for pandora

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:wheezy
+FROM debian:jessie
 
 MAINTAINER Werner Beroux <werner@beroux.com>
 
@@ -20,9 +20,12 @@ ADD https://bootstrap.pypa.io/get-pip.py /tmp/get-pip.py
 RUN python /tmp/get-pip.py
 RUN pip install -U six
 RUN pip install \
+    requests==2.19.1 \
+    cryptography==2.2.2 \
+    pyopenssl==18.0.0 \
     Mopidy-Moped \
     Mopidy-GMusic \
-    Mopidy-YouTube
+    Mopidy-Pandora
 
 # Clean-up to save some space
 RUN apt-get clean
@@ -47,3 +50,5 @@ EXPOSE 6680
 EXPOSE 5555/udp
 
 ENTRYPOINT ["/mopidy.sh"]
+CMD ["/usr/bin/mopidy"]
+

--- a/mopidy.sh
+++ b/mopidy.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-if [[ "$PULSE_COOKIE_DATA" != "" ]]
+if [[ -z "$PULSE_COOKIE_DATA" ]]
 then
     echo -ne $(echo $PULSE_COOKIE_DATA | sed -e 's/../\\x&/g') >$HOME/pulse.cookie
     export PULSE_COOKIE=$HOME/pulse.cookie
 fi
 
-exec /usr/bin/mopidy $*
+exec "$@"


### PR DESCRIPTION
- Mopidy-Youtube is broken and may never be fixed. Swapping it for pandora
- Updating to debian Jessie. Some apt packages were not available on wheezy
- Fixing pulse cookie. It wasn't being generted on startup and audio wouldn't sync