### PR TITLE
Update mopidy.conf

### DIFF
--- a/mopidy.conf
+++ b/mopidy.conf
@@ -1,5 +1,7 @@
+[core]
+data_dir = /var/lib/mopidy
+
 [local]
-data_dir = /var/lib/mopidy/local
 media_dir = /var/lib/mopidy/media
 
 [audio]


### PR DESCRIPTION
I think the config of mopidy changed. To get my setup to work as expected, I had to split the [local] into [core] and [local]. Otherwise it was not saving the scan result.  Also the \local needed to be removed because it was creating it anyways.
The change in the config of mopidy can be seen here https://docs.mopidy.com/en/latest/config/