### PR TITLE
Rollback gpsoauth 1.0.0 to 0.4.3

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -149,11 +149,10 @@
         },
         "gpsoauth": {
             "hashes": [
-                "sha256:149c374863eec17cdac5279d57e4905592a9cd74cc34b7e58671cb19f9238f39",
-                "sha256:1c4d6a980625b8ab6f6f1cf3e30d9b10a6c61ababb2b60bfe4870649e9c82be0"
+                "sha256:b38f654450ec55f130c9414d457355d78030a2c29c5ad8f20b28304a9fc8fad7"
             ],
             "markers": "python_version >= '3.8' and python_version < '4.0'",
-            "version": "==1.0.0"
+            "version": "==0.4.3"
         },
         "httplib2": {
             "hashes": [


### PR DESCRIPTION
in PR #47 gpsoauth was bumped to 1.0.0.
This caused an installation failure as gpsoauth PR https://github.com/simon-weber/gpsoauth/pull/31 set the minimum python version as 3.8 and this docker image is only 3.7.
This PR is to roll back the version to the last version supported by python 3.7 (0.4.3).